### PR TITLE
Add optional local navigation modes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -110,6 +110,9 @@
 	--sr-accent: #c2ad84;
 	--ef-accent: #fefd4d;
 	--card-height: 17rem;
+	--card-width: 14rem;
+	--card-img-height: calc(var(--card-height) - 2.5rem);
+	--card-cat-scale : 1.25;
 	/* Common values across themes */
 	--foreground: oklch(0.985 0.001 106.423);
 	--card-foreground: oklch(0.985 0.001 106.423);
@@ -383,8 +386,6 @@
 	background-position: center;
 }
 [data-theme="gi"] .card-generic {
-	width: 14rem; /* w-56 */
-	height: var(--card-height); /* h-72 */
 	/* cursor: pointer; */
 	/* outline-accent/0 */
 	user-select: none; /* select-none */
@@ -462,8 +463,6 @@
 }
 
 [data-theme="zzz"] .card-generic {
-	width: 14rem; /* w-56 */
-	height: var(--card-height); /* h-72 */
 	/* cursor: pointer; */
 	/* outline-accent/0 */
 	user-select: none; /* select-none */
@@ -820,6 +819,13 @@ a {
 .card-grid-online {
 	grid-auto-rows: 17rem;
 }
+
+.card-grid-cats {
+	grid-template-columns: repeat(auto-fill, minmax(calc(var(--card-width)*var(--card-cat-scale) + 1rem), calc(var(--card-width)*var(--card-cat-scale) + 1rem)));
+	grid-auto-rows: calc(var(--card-cat-scale) * (var(--card-img-height)));
+	row-gap: 1rem;
+	justify-items: center;
+}
 .card-generic {
 	width: 14rem; /* w-56 */
 	height: var(--card-height); /* h-72 */
@@ -834,6 +840,11 @@ a {
 	outline: 0.0625rem solid transparent;
 	transition-duration: 200ms; /* duration-200 */
 	overflow: hidden;
+}
+
+.card-cats{
+	height: calc(var(--card-cat-scale) * (var(--card-img-height)));
+	width: calc( var(--card-cat-scale)* var(--card-width));
 }
 
 .card-online {
@@ -862,7 +873,10 @@ a {
 	outline-color: var(--accent);
 	transform: scale(1.05); /* hover:scale-105 */
 }
-
+.card-cats:hover {
+	outline-color: transparent;
+	transform: scale(1.05); /* hover:scale-105 */
+}
 .card-generic:active {
 	transform: scale(0.95); /* active:scale-95 */
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import {
 	SCALE,
 	SETTINGS,
 	OPTIMIZED,
+	SELECTED,
 } from "./utils/vars";
 import { AnimatePresence, motion, MotionGlobalConfig } from "motion/react";
 import Checklist from "./_Checklist/Checklist";
@@ -88,7 +89,7 @@ function App() {
 	const verticalLayout = !online && localNavigationMode === "vertical";
 	const previousVerticalLayout = useRef(false);
 	const sidebarStateBeforeVertical = useRef({ left: leftSidebarOpen, right: rightSidebarOpen });
-
+	const setSelected = useSetAtom(SELECTED);
 	useLayoutEffect(() => {
 		if (verticalLayout && !previousVerticalLayout.current) {
 			sidebarStateBeforeVertical.current = { left: leftSidebarOpen, right: rightSidebarOpen };
@@ -257,6 +258,7 @@ function App() {
 						exit={{ opacity: 0 }}
 						onClick={() => {
 							setLeftSidebarOpen(false);
+							if (rightSidebarOpen) setSelected("");
 							setRightSidebarOpen(false);
 						}}
 						className="fixed inset-0 z-[9] bg-background/40 backdrop-blur-[calc(var(--blur-xs)*0.5)]"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import {
 	INIT_DONE,
 	LANG,
 	LEFT_SIDEBAR_OPEN,
+	LOCAL_NAVIGATION_MODE,
 	MOD_CHECK_PROGRESS,
 	MOD_LIST,
 	ONLINE,
@@ -24,7 +25,7 @@ import { AnimatePresence, motion, MotionGlobalConfig } from "motion/react";
 import Checklist from "./_Checklist/Checklist";
 import { initializeThemes } from "./utils/theme";
 import Changes from "./_Changes/Changes";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { refreshModList, saveConfigs } from "./utils/filesys";
 import { SidebarProvider } from "./components/ui/sidebar";
 import LeftSidebar from "./_LeftSidebar/Left";
@@ -70,7 +71,8 @@ function App() {
 	const changes = useAtomValue(CHANGES);
 	const settings = useAtomValue(SETTINGS);
 	const animations = useAtomValue(ANIMATIONS);
-	const leftSidebarOpen = useAtomValue(LEFT_SIDEBAR_OPEN);
+	const [leftSidebarOpen, setLeftSidebarOpen] = useAtom(LEFT_SIDEBAR_OPEN);
+	const localNavigationMode = useAtomValue(LOCAL_NAVIGATION_MODE);
 	const scale = useAtomValue(SCALE);
 	const blur = useAtomValue(BLUR);
 	const [rightSidebarOpen, setRightSidebarOpen] = useAtom(RIGHT_SIDEBAR_OPEN);
@@ -83,6 +85,21 @@ function App() {
 	const initializedRef = useRef(false);
 	const [optimized, setOptimized] = useAtom(OPTIMIZED);
 	const [data, setData] = useAtom(DATA);
+	const verticalLayout = !online && localNavigationMode === "vertical";
+	const previousVerticalLayout = useRef(false);
+	const sidebarStateBeforeVertical = useRef({ left: leftSidebarOpen, right: rightSidebarOpen });
+
+	useLayoutEffect(() => {
+		if (verticalLayout && !previousVerticalLayout.current) {
+			sidebarStateBeforeVertical.current = { left: leftSidebarOpen, right: rightSidebarOpen };
+			setLeftSidebarOpen(false);
+			setRightSidebarOpen(false);
+		} else if (!verticalLayout && previousVerticalLayout.current) {
+			setLeftSidebarOpen(sidebarStateBeforeVertical.current.left);
+			setRightSidebarOpen(sidebarStateBeforeVertical.current.right);
+		}
+		previousVerticalLayout.current = verticalLayout;
+	}, [verticalLayout, leftSidebarOpen, rightSidebarOpen, setLeftSidebarOpen, setRightSidebarOpen]);
 
 	const [isOptimizing, setIsOptimizing] = useState(false);
 
@@ -202,15 +219,15 @@ function App() {
 	}, [online]);
 	const leftSidebarStyle = useMemo(
 		() => ({
-			minWidth: leftSidebarOpen ? "20.95rem" : "3.95rem",
+			minWidth: verticalLayout ? "3.95rem" : leftSidebarOpen ? "20.95rem" : "3.95rem",
 		}),
-		[leftSidebarOpen]
+		[leftSidebarOpen, verticalLayout]
 	);
 	const rightSidebarStyle = useMemo(
 		() => ({
-			minWidth: rightSidebarOpen ? "20.95rem" : "0rem",
+			minWidth: verticalLayout ? "0rem" : rightSidebarOpen ? "20.95rem" : "0rem",
 		}),
-		[rightSidebarOpen]
+		[rightSidebarOpen, verticalLayout]
 	);
 	return (
 		<div id="background" className="game-font fixed border-b flex flex-row items-start justify-start w-full h-full">
@@ -230,6 +247,22 @@ function App() {
 				<RightLocal />
 			</SidebarProvider>
 			<RightOnline open={online && rightSlideOverOpen} />
+			<AnimatePresence>
+				{verticalLayout && (leftSidebarOpen || rightSidebarOpen) && (
+					<motion.button
+						type="button"
+						aria-label="Close sidebar"
+						initial={{ opacity: 0 }}
+						animate={{ opacity: 1 }}
+						exit={{ opacity: 0 }}
+						onClick={() => {
+							setLeftSidebarOpen(false);
+							setRightSidebarOpen(false);
+						}}
+						className="fixed inset-0 z-[9] bg-background/40 backdrop-blur-[calc(var(--blur-xs)*0.5)]"
+					/>
+				)}
+			</AnimatePresence>
 			<div className="fixed flex flex-row w-full h-full">
 				<div className="h-full duration-200 ease-linear" style={leftSidebarStyle} />
 				<Main />

--- a/src/_Main/Main.tsx
+++ b/src/_Main/Main.tsx
@@ -1,7 +1,7 @@
 import { AnimatePresence, motion } from "motion/react";
 import { useAtom, useAtomValue } from "jotai";
 import { CONFLICTS_OPEN, ONLINE } from "@/utils/vars";
-import MainLocal from "./MainLocal";
+import MainLocalNavigation from "./MainLocalNavigation";
 import MainOnline from "./MainOnline";
 import BottomBar from "./components/BottomBar";
 import TopBar from "./components/TopBar";
@@ -34,7 +34,7 @@ function Main() {
 						key={online == debouncedOnline ? (online ? "online" : "local") : "transitioning"}
 						className=" flex flex-col items-center h-full min-w-full overflow-y-hidden delay-200"
 					>
-						{online == debouncedOnline ? online ? <MainOnline /> : <MainLocal /> : <></>}
+						{online == debouncedOnline ? online ? <MainOnline /> : <MainLocalNavigation /> : <></>}
 					</motion.div>
 				</AnimatePresence>
 			</div>

--- a/src/_Main/MainLocal.tsx
+++ b/src/_Main/MainLocal.tsx
@@ -29,9 +29,6 @@ import { openPath } from "@tauri-apps/plugin-opener";
 import { Mod } from "@/utils/types";
 import { addToast } from "@/_Toaster/ToastProvider";
 import { info } from "@/lib/logger";
-// import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-// import { RefreshCwIcon } from "lucide-react";
-// import { addToast } from "@/_Toaster/ToastProvider";
 const modKeys = [
 	"isDir",
 	"name",
@@ -53,7 +50,7 @@ const modKeys = [
 	"crop",
 	"maxed",
 ];
-function MainLocal({ compact = false }: { compact?: boolean }) {
+function MainLocal({ compact = false, isCategory = false }: { compact?: boolean; isCategory?: boolean }) {
 	const initDone = useAtomValue(INIT_DONE);
 	const textData = useAtomValue(TEXT_DATA);
 	const [conflicts, setConflicts] = useAtom(CONFLICTS);
@@ -289,8 +286,8 @@ function MainLocal({ compact = false }: { compact?: boolean }) {
 				const scale = parseInt((document.documentElement.style.fontSize || "16px").replace("px", ""))/16;
 				const box = containerRef.current.getBoundingClientRect();
 				const scrollTop = containerRef.current.scrollTop;
-				const itemHeight = (compact ? 352 : 304) * scale;
-				const itemWidth = (compact ? 240 : 256) * scale;
+				const itemHeight = 304 * scale;
+				const itemWidth = 256 * scale;
 				const itemsPerRow = Math.max(1, Math.floor((box.width - 10) / itemWidth));
 				info(itemsPerRow, itemWidth, box.width - 10);
 				setVisibleRange({
@@ -299,7 +296,7 @@ function MainLocal({ compact = false }: { compact?: boolean }) {
 				});
 			}
 		}, 50);
-	}, [compact, initial]);
+	}, [initial]);
 
 	// Memoize animation variants to prevent recreation on every render
 	const animationVariants = useCallback(
@@ -352,7 +349,7 @@ function MainLocal({ compact = false }: { compact?: boolean }) {
 				className="flex flex-col items-center w-full h-screen overflow-x-hidden overflow-y-auto duration-300"
 			>
 				{" "}
-				<label className="text-muted z-200 flex flex-col items-center gap-1">
+				{!isCategory && <label className="text-muted z-200 flex flex-col items-center gap-1">
 					<label className="flex items-center">
 						{filteredList.length} {textData.Items}{" "}
 					</label>
@@ -368,11 +365,12 @@ function MainLocal({ compact = false }: { compact?: boolean }) {
 						</label>
 					</label>
 				</label>
+				}
 				{noItems}
 				<AnimatePresence mode="popLayout">
 					<motion.div
 						layout
-						className={compact ? "min-h-fit grid w-full grid-cols-[repeat(auto-fill,minmax(15rem,1fr))] gap-4 px-4 py-4 [--card-height:20rem] [&_.card-generic]:!w-full" : "min-h-fit card-grid grid justify-center w-full py-4"}
+						className="min-h-fit card-grid grid justify-center w-full py-4"
 						key={keyRef.current}
 						initial={{ opacity: 0, pointerEvents: "none" }}
 						animate={{ opacity: 1, pointerEvents: "auto" }}

--- a/src/_Main/MainLocal.tsx
+++ b/src/_Main/MainLocal.tsx
@@ -9,12 +9,13 @@ import {
 	openConflict,
 	SEARCH,
 	SELECTED,
+	RIGHT_SIDEBAR_OPEN,
 	SETTINGS,
 	SORT,
 	SOURCE,
 	TEXT_DATA,
 } from "@/utils/vars";
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { AnimatePresence, motion } from "motion/react";
 import CardLocal from "./components/CardLocal";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -52,7 +53,7 @@ const modKeys = [
 	"crop",
 	"maxed",
 ];
-function MainLocal() {
+function MainLocal({ compact = false }: { compact?: boolean }) {
 	const initDone = useAtomValue(INIT_DONE);
 	const textData = useAtomValue(TEXT_DATA);
 	const [conflicts, setConflicts] = useAtom(CONFLICTS);
@@ -74,6 +75,7 @@ function MainLocal() {
 	const [filteredList, setFilteredList] = useState([] as Mod[]);
 	const [visibleRange, setVisibleRange] = useState({ start: -1, end: -1 });
 	const [selected, setSelected] = useAtom(SELECTED);
+	const setRightSidebarOpen = useSetAtom(RIGHT_SIDEBAR_OPEN);
 	const containerRef = useRef<HTMLDivElement | null>(null);
 	const toggleOn = useAtomValue(SETTINGS).global.local.toggleClick;
 	const sort = useAtomValue(SORT);
@@ -271,7 +273,11 @@ function MainLocal() {
 						return m;
 					});
 				});
-		} else setSelected(mod.path == selected ? "" : mod.path);
+		} else {
+			const nextSelected = mod.path == selected ? "" : mod.path;
+			setSelected(nextSelected);
+			if (compact) setRightSidebarOpen(!!nextSelected);
+		}
 	};
 	const handleScroll = useCallback(() => {
 		if (initial) {
@@ -283,9 +289,9 @@ function MainLocal() {
 				const scale = parseInt((document.documentElement.style.fontSize || "16px").replace("px", ""))/16;
 				const box = containerRef.current.getBoundingClientRect();
 				const scrollTop = containerRef.current.scrollTop;
-				const itemHeight = 304 * scale;
-				const itemWidth = 256 * scale;
-				const itemsPerRow = Math.floor((box.width - 10) / itemWidth);
+				const itemHeight = (compact ? 352 : 304) * scale;
+				const itemWidth = (compact ? 240 : 256) * scale;
+				const itemsPerRow = Math.max(1, Math.floor((box.width - 10) / itemWidth));
 				info(itemsPerRow, itemWidth, box.width - 10);
 				setVisibleRange({
 					start: Math.floor(scrollTop / itemHeight) * itemsPerRow,
@@ -293,7 +299,7 @@ function MainLocal() {
 				});
 			}
 		}, 50);
-	}, [initial]);
+	}, [compact, initial]);
 
 	// Memoize animation variants to prevent recreation on every render
 	const animationVariants = useCallback(
@@ -366,7 +372,7 @@ function MainLocal() {
 				<AnimatePresence mode="popLayout">
 					<motion.div
 						layout
-						className="min-h-fit card-grid grid justify-center w-full py-4"
+						className={compact ? "min-h-fit grid w-full grid-cols-[repeat(auto-fill,minmax(15rem,1fr))] gap-4 px-4 py-4 [--card-height:20rem] [&_.card-generic]:!w-full" : "min-h-fit card-grid grid justify-center w-full py-4"}
 						key={keyRef.current}
 						initial={{ opacity: 0, pointerEvents: "none" }}
 						animate={{ opacity: 1, pointerEvents: "auto" }}

--- a/src/_Main/MainLocalCats.tsx
+++ b/src/_Main/MainLocalCats.tsx
@@ -1,0 +1,158 @@
+import { Category, Mod } from "@/utils/types";
+import { getImageUrl, preventContextMenu } from "@/utils/utils";
+import {
+	CATEGORIES,
+	CATEGORY,
+	LAST_UPDATED,
+	LOCAL_CATEGORY_FAVORITES,
+	LOCAL_NAVIGATION_PAGE,
+	MOD_LIST,
+} from "@/utils/vars";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { useCallback, useMemo, useState } from "react";
+import { AnimatePresence, motion } from "motion/react";
+import CardLocalCats from "./components/CardLocalCats";
+interface CategoryCard {
+	name: string;
+	icon: Category["_sIconUrl"];
+	mods: Mod[];
+	favorite: boolean;
+}
+let prevScrollTop = 0;
+function MainLocalCats({
+	resetNavigationFilters,
+	toggleFav,
+}: {
+	resetNavigationFilters: () => void;
+	toggleFav: (enabled: boolean) => void;
+}) {
+	const initial = useState(true);
+	const setCategory = useSetAtom(CATEGORY);
+	const setPage = useSetAtom(LOCAL_NAVIGATION_PAGE);
+	const [favoriteCategories, setFavoriteCategories] = useAtom(LOCAL_CATEGORY_FAVORITES);
+	const categories = useAtomValue(CATEGORIES);
+	const mods = useAtomValue(MOD_LIST);
+	const lastUpdated = useAtomValue(LAST_UPDATED);
+	let vertical = false;
+	const categoryCards = useMemo<CategoryCard[]>(() => {
+		const favorites = new Set(favoriteCategories);
+		const categoryMap = Object.fromEntries(categories.map((category) => [category._sName, category]));
+		const FavMods = mods.filter((mod) => mod.tags?.includes("fav"));
+		const grouped = {} as Record<string, Mod[]>;
+		for (const mod of mods) {
+			const categoryName = mod.parent;
+			if (!grouped[categoryName]) {
+				grouped[categoryName] = [];
+			}
+			grouped[categoryName].push(mod);
+		}
+		return [
+			...(FavMods.length > 0
+				? [
+						{
+							name: "Favorites",
+							icon: "heart",
+							mods: FavMods,
+							favorite: true,
+						},
+					]
+				: []),
+			...Object.entries(grouped)
+				.map(([categoryName, mods]) => ({
+					name: categoryName,
+					icon: categoryMap[categoryName]?._sIconUrl || "folder",
+					mods: mods,
+					favorite: favorites.has(categoryName),
+				}))
+				.sort((a, b) => {
+					if (a.favorite !== b.favorite) return a.favorite ? -1 : 1;
+					return a.name.localeCompare(b.name);
+				}),
+		];
+	}, [categories, favoriteCategories, mods]);
+	const openCategory = (categoryName: string, isFirst = false) => {
+		resetNavigationFilters();
+		if (isFirst) {
+			toggleFav(true);
+		} else {
+			setCategory(new Set([categoryName]));
+		}
+		setPage("mods");
+	};
+
+	const transitionConfig = useCallback(
+		(index: number) => ({
+			duration: 0.3,
+			ease: "easeOut" as const,
+			delay: initial ? 0.05 * index : 0,
+		}),
+		[initial]
+	);
+
+	const toggleCategoryFavorite = (event: React.MouseEvent, categoryName: string) => {
+		event.preventDefault();
+		event.stopPropagation();
+		setFavoriteCategories((previous) =>
+			previous.includes(categoryName) ? previous.filter((name) => name !== categoryName) : [...previous, categoryName]
+		);
+	};
+	return (
+		<div
+			className={`h-full w-full overflow-y-auto pb-6 ${vertical ? "px-3" : "px-5"}`}
+			onLoad={(e) => {
+				prevScrollTop = Math.max(1, prevScrollTop);
+				e.currentTarget.scrollTop = prevScrollTop;
+			}}
+			onScroll={(e) => {
+				e.currentTarget.scrollTop = Math.max(1, e.currentTarget.scrollTop);
+				prevScrollTop = e.currentTarget.scrollTop;
+			}}
+		>
+			<div className="top-0 z-20 border-b bg-background/95 px-1 py-4 backdrop-blur">
+				<h2 className="text-3xl text-accent">Browse by category</h2>
+				<p className="text-xs text-muted-foreground">
+					{mods.length} total mods · Open a category folder to view its mods.
+				</p>
+			</div>
+			<AnimatePresence mode="popLayout" initial={prevScrollTop === 0}>
+				<div className="min-h-fit card-grid card-grid-cats grid justify-center w-full py-4">
+					{categoryCards.map((card, index) => {
+						const previews = card.mods
+							.map((x) => ({
+								src: getImageUrl(x.path) + `?${lastUpdated}`,
+								crop: x.crop,
+							}))
+							.filter((x) => x.src);
+						const enabledCount = card.mods.filter((mod) => mod.enabled).length;
+						return (
+							<motion.div
+								key={card.name}
+								layout
+								initial={{ opacity: 0, y: 20 }}
+								animate={{ opacity: 1, y: 0 }}
+								exit={{ opacity: 0, y: -20 }}
+								transition={transitionConfig(index)}
+								onMouseUp={() => openCategory(card.name)}
+								onContextMenu={preventContextMenu}
+							>
+								<CardLocalCats
+									{...{
+										card,
+										openCategory,
+										enabledCount,
+										previews,
+										index,
+										toggleCategoryFavorite,
+										initial: prevScrollTop === 0,
+									}}
+								/>
+							</motion.div>
+						);
+					})}
+				</div>
+			</AnimatePresence>
+		</div>
+	);
+}
+
+export default MainLocalCats;

--- a/src/_Main/MainLocalNavigation.tsx
+++ b/src/_Main/MainLocalNavigation.tsx
@@ -1,39 +1,17 @@
 import { Button } from "@/components/ui/button";
-import { Category, Mod } from "@/utils/types";
-import { getImageUrl } from "@/utils/utils";
-import {
-	CATEGORIES,
-	CATEGORY,
-	FILTER,
-	LAST_UPDATED,
-	LOCAL_CATEGORY_FAVORITES,
-	LOCAL_NAVIGATION_MODE,
-	LOCAL_NAVIGATION_PAGE,
-	MOD_LIST,
-	SEARCH,
-	SORT,
-} from "@/utils/vars";
+import { CATEGORY, FILTER, LOCAL_NAVIGATION_MODE, LOCAL_NAVIGATION_PAGE, SEARCH, SORT } from "@/utils/vars";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
-import { ArrowLeftIcon, FolderOpenIcon, HeartIcon, ImageOffIcon } from "lucide-react";
-import { useEffect, useMemo } from "react";
+import { ArrowLeftIcon } from "lucide-react";
+import { useEffect } from "react";
 import MainLocal from "./MainLocal";
-
-interface CategoryCard {
-	name: string;
-	icon: Category["_sIconUrl"];
-	mods: Mod[];
-	favorite: boolean;
-}
+import MainLocalCats from "./MainLocalCats";
+import { AnimatePresence, motion } from "motion/react";
 
 function MainLocalNavigation() {
 	const mode = useAtomValue(LOCAL_NAVIGATION_MODE);
 	const vertical = mode === "vertical";
 	const [page, setPage] = useAtom(LOCAL_NAVIGATION_PAGE);
-	const categories = useAtomValue(CATEGORIES);
-	const mods = useAtomValue(MOD_LIST);
-	const lastUpdated = useAtomValue(LAST_UPDATED);
 	const selectedCategories = useAtomValue(CATEGORY);
-	const [favoriteCategories, setFavoriteCategories] = useAtom(LOCAL_CATEGORY_FAVORITES);
 	const [search, setSearch] = useAtom(SEARCH);
 	const setCategory = useSetAtom(CATEGORY);
 	const setFilter = useSetAtom(FILTER);
@@ -42,22 +20,21 @@ function MainLocalNavigation() {
 	useEffect(() => {
 		if (mode !== "classic" && selectedCategories.size > 0) setPage("mods");
 	}, [mode, selectedCategories, setPage]);
-
-	const categoryCards = useMemo<CategoryCard[]>(() => {
-		const favorites = new Set(favoriteCategories);
-		return categories
-			.map((category) => ({
-				name: category._sName,
-				icon: category._sIconUrl,
-				mods: mods.filter((mod) => mod.parent === category._sName),
-				favorite: favorites.has(category._sName),
-			}))
-			.filter((card) => card.mods.length > 0)
-			.sort((a, b) => {
-				if (a.favorite !== b.favorite) return a.favorite ? -1 : 1;
-				return a.name.localeCompare(b.name);
-			});
-	}, [categories, favoriteCategories, mods]);
+	useEffect(() => {
+		if (!search.trim()) {
+			const back = (e: KeyboardEvent) => {
+				if (e.key === "Escape" && (e.target as HTMLElement)?.tagName !== "INPUT" && (e.target as HTMLElement)?.tagName !== "TEXTAREA") {
+					resetNavigationFilters();
+					setPage("categories");
+				}
+			};
+			window.addEventListener("keydown", back);
+			return () => {
+				window.removeEventListener("keydown", back);
+			};
+		}
+		return () => {};
+	}, [mode, search]);
 
 	if (mode === "classic") return <MainLocal />;
 
@@ -70,124 +47,61 @@ function MainLocalNavigation() {
 		setSort("default");
 	};
 
-	const openCategory = (categoryName: string) => {
-		resetNavigationFilters();
-		setCategory(new Set([categoryName]));
-		setPage("mods");
+	const toggleFav = (enabled: boolean) => {
+		setFilter((previous) => ({
+			...previous,
+			tag: { ...(previous.tag as Record<string, string>), fav: enabled ? "has" : "any" },
+		}));
 	};
-
-	const toggleCategoryFavorite = (event: React.MouseEvent, categoryName: string) => {
-		event.preventDefault();
-		event.stopPropagation();
-		setFavoriteCategories((previous) =>
-			previous.includes(categoryName)
-				? previous.filter((name) => name !== categoryName)
-				: [...previous, categoryName]
-		);
-	};
-
-	if (page === "mods" || search.trim()) {
-		return (
-			<div className="flex h-full w-full flex-col overflow-hidden">
-				<div className={vertical ? "sticky top-0 z-10 flex w-full items-center bg-background/80 px-2 pb-1 backdrop-blur-sm" : "flex w-full items-center px-2 pb-1"}>
-					<Button
-						variant="ghost"
-						className="h-9 gap-2"
-						onClick={() => {
-							resetNavigationFilters();
-							setSearch("");
-							setPage("categories");
-						}}
-					>
-						<ArrowLeftIcon className="h-4 w-4" /> Back to categories
-					</Button>
-				</div>
-				<div className="min-h-0 flex-1">
-					<MainLocal compact={vertical} />
-				</div>
-			</div>
-		);
-	}
 
 	return (
-		<div className={`h-full w-full overflow-y-auto pb-6 ${vertical ? "px-3" : "px-5"}`}>
-			<div className="sticky top-0 z-20 border-b bg-background/95 px-1 py-4 backdrop-blur">
-				<p className="text-[10px] font-bold uppercase tracking-[0.2em] text-accent">Mod library</p>
-				<h2 className="font-serif text-3xl text-accent">Browse by category</h2>
-				<p className="text-xs text-muted-foreground">
-					{mods.length} total mods · Open a category folder to view its mods.
-				</p>
-			</div>
-			<div className={`grid w-full justify-start pt-4 ${vertical ? "grid-cols-[repeat(auto-fill,minmax(15rem,1fr))] gap-3" : "grid-cols-[repeat(auto-fill,19rem)] gap-5"}`}>
-				{categoryCards.map((card) => {
-					const firstPreview = card.mods[0];
-					const enabledCount = card.mods.filter((mod) => mod.enabled).length;
-					return (
-						<div
-							key={card.name}
-							onClick={() => openCategory(card.name)}
-							role="button"
-							tabIndex={0}
-							onKeyDown={(event) => {
-								if (event.key === "Enter" || event.key === " ") {
-									event.preventDefault();
-									openCategory(card.name);
-								}
-							}}
-							className={`group relative overflow-hidden rounded-xl border bg-sidebar text-left shadow-lg duration-200 hover:-translate-y-1 hover:border-accent ${vertical ? "min-h-60" : "min-h-96"}`}
-						>
+		<div className="flex relative h-full w-full flex-col overflow-hidden">
+			<AnimatePresence initial={false}>
+				{page === "mods" || search.trim() ? (
+					<motion.div
+						key="mods"
+						initial={{ opacity: 0, scale: 0.95 }}
+						animate={{ opacity: 1, scale: 1 }}
+						exit={{ opacity: 0, scale: 0.95 }}
+						transition={{
+							duration: 1,
+							type: "spring",
+						}}
+						className="flex absolute h-full w-full flex-col gap-0 overflow-hidden"
+					>
+						<div className="flex w-full items-center px-2 pb-1 -mb-2">
 							<Button
-								onMouseDown={(event) => event.stopPropagation()}
-								onMouseUp={(event) => event.stopPropagation()}
-								onClick={(event) => toggleCategoryFavorite(event, card.name)}
-								title={card.favorite ? "Remove favorite category" : "Add favorite category"}
-								className="absolute right-3 top-3 z-20 h-9 w-9 rounded-full border bg-background/70 p-0 backdrop-blur hover:bg-background"
+								variant="ghost"
+								className="h-9 gap-2 hover:text-background"
+								onClick={() => {
+									resetNavigationFilters();
+									setSearch("");
+									setPage("categories");
+								}}
 							>
-								<HeartIcon
-									className="h-4 w-4"
-									style={{ color: card.favorite ? "var(--color-red-400)" : "", fill: card.favorite ? "currentColor" : "none" }}
-								/>
+								<ArrowLeftIcon className="h-4 w-4" /> Back to categories
 							</Button>
-							{firstPreview ? (
-								<img
-									src={`${getImageUrl(firstPreview.path)}?${lastUpdated}`}
-									alt=""
-									onError={(event) => {
-										event.currentTarget.hidden = true;
-									}}
-									className="absolute inset-0 h-full w-full object-cover opacity-55 blur-[1px] duration-200 group-hover:opacity-70 group-hover:blur-0"
-								/>
-							) : (
-								<div className="absolute inset-0 grid place-items-center bg-background/40">
-									<ImageOffIcon className="h-12 w-12 text-muted-foreground" />
-								</div>
-							)}
-							<div className="absolute inset-0 bg-gradient-to-t from-background via-background/35 to-transparent" />
-							<span className="absolute right-3 top-14 z-10 rounded-md border bg-background/70 px-2 py-1 text-[11px] text-accent">
-								{enabledCount} {enabledCount === 1 ? "enabled mod" : "enabled mods"}
-							</span>
-							<div className={`relative flex h-full flex-col justify-between p-4 ${vertical ? "min-h-60" : "min-h-96"}`}>
-								<img
-									src={card.icon || "/who.jpg"}
-									alt=""
-									onError={(event) => {
-										event.currentTarget.src = "/who.jpg";
-									}}
-									className="h-14 w-14 rounded-lg border bg-background object-cover"
-								/>
-								<div>
-									<p className="text-[10px] font-bold uppercase tracking-[0.12em] text-accent">Folder</p>
-									<h3 className="line-clamp-2 text-xl font-bold text-foreground">{card.name}</h3>
-									<p className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
-										<FolderOpenIcon className="h-3.5 w-3.5" />
-										{card.mods.length} mods
-									</p>
-								</div>
-							</div>
 						</div>
-					);
-				})}
-			</div>
+						<div className="min-h-0 flex-1">
+							<MainLocal compact={vertical} isCategory={true} />
+						</div>
+					</motion.div>
+				) : (
+					<motion.div
+						key="categories"
+						initial={{ opacity: 0, scale: 1.05 }}
+						animate={{ opacity: 1, scale: 1 }}
+						exit={{ opacity: 0, scale: 1.05 }}
+						transition={{
+							duration: 1,
+							type: "spring",
+						}}
+						className="flex absolute h-full w-full flex-col overflow-hidden"
+					>
+						<MainLocalCats resetNavigationFilters={resetNavigationFilters} toggleFav={toggleFav} />
+					</motion.div>
+				)}
+			</AnimatePresence>
 		</div>
 	);
 }

--- a/src/_Main/MainLocalNavigation.tsx
+++ b/src/_Main/MainLocalNavigation.tsx
@@ -1,0 +1,195 @@
+import { Button } from "@/components/ui/button";
+import { Category, Mod } from "@/utils/types";
+import { getImageUrl } from "@/utils/utils";
+import {
+	CATEGORIES,
+	CATEGORY,
+	FILTER,
+	LAST_UPDATED,
+	LOCAL_CATEGORY_FAVORITES,
+	LOCAL_NAVIGATION_MODE,
+	LOCAL_NAVIGATION_PAGE,
+	MOD_LIST,
+	SEARCH,
+	SORT,
+} from "@/utils/vars";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { ArrowLeftIcon, FolderOpenIcon, HeartIcon, ImageOffIcon } from "lucide-react";
+import { useEffect, useMemo } from "react";
+import MainLocal from "./MainLocal";
+
+interface CategoryCard {
+	name: string;
+	icon: Category["_sIconUrl"];
+	mods: Mod[];
+	favorite: boolean;
+}
+
+function MainLocalNavigation() {
+	const mode = useAtomValue(LOCAL_NAVIGATION_MODE);
+	const vertical = mode === "vertical";
+	const [page, setPage] = useAtom(LOCAL_NAVIGATION_PAGE);
+	const categories = useAtomValue(CATEGORIES);
+	const mods = useAtomValue(MOD_LIST);
+	const lastUpdated = useAtomValue(LAST_UPDATED);
+	const selectedCategories = useAtomValue(CATEGORY);
+	const [favoriteCategories, setFavoriteCategories] = useAtom(LOCAL_CATEGORY_FAVORITES);
+	const [search, setSearch] = useAtom(SEARCH);
+	const setCategory = useSetAtom(CATEGORY);
+	const setFilter = useSetAtom(FILTER);
+	const setSort = useSetAtom(SORT);
+
+	useEffect(() => {
+		if (mode !== "classic" && selectedCategories.size > 0) setPage("mods");
+	}, [mode, selectedCategories, setPage]);
+
+	const categoryCards = useMemo<CategoryCard[]>(() => {
+		const favorites = new Set(favoriteCategories);
+		return categories
+			.map((category) => ({
+				name: category._sName,
+				icon: category._sIconUrl,
+				mods: mods.filter((mod) => mod.parent === category._sName),
+				favorite: favorites.has(category._sName),
+			}))
+			.filter((card) => card.mods.length > 0)
+			.sort((a, b) => {
+				if (a.favorite !== b.favorite) return a.favorite ? -1 : 1;
+				return a.name.localeCompare(b.name);
+			});
+	}, [categories, favoriteCategories, mods]);
+
+	if (mode === "classic") return <MainLocal />;
+
+	const resetNavigationFilters = () => {
+		setCategory(new Set());
+		setFilter((previous) => ({
+			...previous,
+			tag: { ...(previous.tag as Record<string, string>), fav: "any" },
+		}));
+		setSort("default");
+	};
+
+	const openCategory = (categoryName: string) => {
+		resetNavigationFilters();
+		setCategory(new Set([categoryName]));
+		setPage("mods");
+	};
+
+	const toggleCategoryFavorite = (event: React.MouseEvent, categoryName: string) => {
+		event.preventDefault();
+		event.stopPropagation();
+		setFavoriteCategories((previous) =>
+			previous.includes(categoryName)
+				? previous.filter((name) => name !== categoryName)
+				: [...previous, categoryName]
+		);
+	};
+
+	if (page === "mods" || search.trim()) {
+		return (
+			<div className="flex h-full w-full flex-col overflow-hidden">
+				<div className={vertical ? "sticky top-0 z-10 flex w-full items-center bg-background/80 px-2 pb-1 backdrop-blur-sm" : "flex w-full items-center px-2 pb-1"}>
+					<Button
+						variant="ghost"
+						className="h-9 gap-2"
+						onClick={() => {
+							resetNavigationFilters();
+							setSearch("");
+							setPage("categories");
+						}}
+					>
+						<ArrowLeftIcon className="h-4 w-4" /> Back to categories
+					</Button>
+				</div>
+				<div className="min-h-0 flex-1">
+					<MainLocal compact={vertical} />
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className={`h-full w-full overflow-y-auto pb-6 ${vertical ? "px-3" : "px-5"}`}>
+			<div className="sticky top-0 z-20 border-b bg-background/95 px-1 py-4 backdrop-blur">
+				<p className="text-[10px] font-bold uppercase tracking-[0.2em] text-accent">Mod library</p>
+				<h2 className="font-serif text-3xl text-accent">Browse by category</h2>
+				<p className="text-xs text-muted-foreground">
+					{mods.length} total mods · Open a category folder to view its mods.
+				</p>
+			</div>
+			<div className={`grid w-full justify-start pt-4 ${vertical ? "grid-cols-[repeat(auto-fill,minmax(15rem,1fr))] gap-3" : "grid-cols-[repeat(auto-fill,19rem)] gap-5"}`}>
+				{categoryCards.map((card) => {
+					const firstPreview = card.mods[0];
+					const enabledCount = card.mods.filter((mod) => mod.enabled).length;
+					return (
+						<div
+							key={card.name}
+							onClick={() => openCategory(card.name)}
+							role="button"
+							tabIndex={0}
+							onKeyDown={(event) => {
+								if (event.key === "Enter" || event.key === " ") {
+									event.preventDefault();
+									openCategory(card.name);
+								}
+							}}
+							className={`group relative overflow-hidden rounded-xl border bg-sidebar text-left shadow-lg duration-200 hover:-translate-y-1 hover:border-accent ${vertical ? "min-h-60" : "min-h-96"}`}
+						>
+							<Button
+								onMouseDown={(event) => event.stopPropagation()}
+								onMouseUp={(event) => event.stopPropagation()}
+								onClick={(event) => toggleCategoryFavorite(event, card.name)}
+								title={card.favorite ? "Remove favorite category" : "Add favorite category"}
+								className="absolute right-3 top-3 z-20 h-9 w-9 rounded-full border bg-background/70 p-0 backdrop-blur hover:bg-background"
+							>
+								<HeartIcon
+									className="h-4 w-4"
+									style={{ color: card.favorite ? "var(--color-red-400)" : "", fill: card.favorite ? "currentColor" : "none" }}
+								/>
+							</Button>
+							{firstPreview ? (
+								<img
+									src={`${getImageUrl(firstPreview.path)}?${lastUpdated}`}
+									alt=""
+									onError={(event) => {
+										event.currentTarget.hidden = true;
+									}}
+									className="absolute inset-0 h-full w-full object-cover opacity-55 blur-[1px] duration-200 group-hover:opacity-70 group-hover:blur-0"
+								/>
+							) : (
+								<div className="absolute inset-0 grid place-items-center bg-background/40">
+									<ImageOffIcon className="h-12 w-12 text-muted-foreground" />
+								</div>
+							)}
+							<div className="absolute inset-0 bg-gradient-to-t from-background via-background/35 to-transparent" />
+							<span className="absolute right-3 top-14 z-10 rounded-md border bg-background/70 px-2 py-1 text-[11px] text-accent">
+								{enabledCount} {enabledCount === 1 ? "enabled mod" : "enabled mods"}
+							</span>
+							<div className={`relative flex h-full flex-col justify-between p-4 ${vertical ? "min-h-60" : "min-h-96"}`}>
+								<img
+									src={card.icon || "/who.jpg"}
+									alt=""
+									onError={(event) => {
+										event.currentTarget.src = "/who.jpg";
+									}}
+									className="h-14 w-14 rounded-lg border bg-background object-cover"
+								/>
+								<div>
+									<p className="text-[10px] font-bold uppercase tracking-[0.12em] text-accent">Folder</p>
+									<h3 className="line-clamp-2 text-xl font-bold text-foreground">{card.name}</h3>
+									<p className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
+										<FolderOpenIcon className="h-3.5 w-3.5" />
+										{card.mods.length} mods
+									</p>
+								</div>
+							</div>
+						</div>
+					);
+				})}
+			</div>
+		</div>
+	);
+}
+
+export default MainLocalNavigation;

--- a/src/_Main/components/BottomBar.tsx
+++ b/src/_Main/components/BottomBar.tsx
@@ -1,6 +1,16 @@
 import { Button } from "@/components/ui/button";
 import { UNCATEGORIZED } from "@/utils/consts";
-import { CATEGORIES, CATEGORY, MOD_LIST, ONLINE, ONLINE_PATH, ONLINE_SORT, ONLINE_TYPE, TEXT_DATA } from "@/utils/vars";
+import {
+	CATEGORIES,
+	CATEGORY,
+	LOCAL_NAVIGATION_MODE,
+	MOD_LIST,
+	ONLINE,
+	ONLINE_PATH,
+	ONLINE_SORT,
+	ONLINE_TYPE,
+	TEXT_DATA,
+} from "@/utils/vars";
 import { useAtom, useAtomValue } from "jotai";
 import { ChevronUpIcon, FileQuestionIcon, GroupIcon } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
@@ -8,6 +18,7 @@ import { useMemo, useState } from "react";
 
 function BottomBar() {
 	const textData = useAtomValue(TEXT_DATA);
+	const mode = useAtomValue(LOCAL_NAVIGATION_MODE);
 	const [category, setCategory] = useAtom(CATEGORY);
 	const [onlinePath, setOnlinePath] = useAtom(ONLINE_PATH);
 	const onlineType = useAtomValue(ONLINE_TYPE);
@@ -16,6 +27,8 @@ function BottomBar() {
 	const modList = useAtomValue(MOD_LIST);
 	const categories = useAtomValue(CATEGORIES);
 	const [expanded, setExpanded] = useState(false);
+	if (mode !== "classic" && expanded && !online) setExpanded(false);
+
 	const localCategories = useMemo(() => {
 		// info("Online Path:", onlinePath);
 		return online
@@ -35,12 +48,13 @@ function BottomBar() {
 					...categories.filter((cat) => modList.some((mod) => mod.parent == cat._sName)),
 				];
 	}, [categories, modList, online, onlinePath]);
-	console.log(onlinePath)
+	console.log(onlinePath);
 	return (
 		<div
 			className="min-h-20 duration-200 flex items-center justify-center w-full h-20 p-2"
 			style={{
 				height: expanded ? "16rem" : "",
+				marginBottom: mode == "classic" ? "" : "-4.75rem",
 			}}
 		>
 			<div className="bg-sidebar data-zzz:rounded-[3rem] data-gi:rounded-[3rem] z-100 text-accent flex items-center justify-center w-full h-full gap-1 p-2 border rounded-lg">

--- a/src/_Main/components/CardLocalCats.tsx
+++ b/src/_Main/components/CardLocalCats.tsx
@@ -1,0 +1,161 @@
+import { Button } from "@/components/ui/button";
+import { Mod } from "@/utils/types";
+import { handleImageError } from "@/utils/utils";
+import { HeartIcon } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
+import React, { useEffect, useState } from "react";
+
+const CardLocalCats = React.memo(
+	({
+		card,
+		openCategory,
+		toggleCategoryFavorite,
+		enabledCount,
+		previews,
+		index,
+		initial,
+	}: {
+		card: {
+			name: string;
+			icon: string;
+			mods: Mod[];
+			favorite: boolean;
+		};
+		openCategory: (categoryName: string, isFirst?: boolean) => void;
+		toggleCategoryFavorite: (event: React.MouseEvent<HTMLButtonElement>, categoryName: string) => void;
+		enabledCount: number;
+		previews: {
+			src: string;
+			crop:
+				| {
+						x?: number;
+						y?: number;
+						scale?: number;
+				  }
+				| undefined;
+		}[];
+		index: number;
+		initial: boolean;
+	}) => {
+		const [previewIndex, setPreviewIndex] = useState(0);
+		useEffect(() => {
+			if (previews.length > 1) {
+				let timeout: number | undefined;
+				const timeoutFunction = () => {
+					setPreviewIndex((prevIndex) => (prevIndex + 1) % previews.length);
+					timeout = setTimeout(timeoutFunction, 7000 + index * 500 + Math.floor(Math.random() * 500));
+				};
+				timeout = setTimeout(timeoutFunction, 7000 + index * 500 + Math.floor(Math.random() * 500));
+				return () => clearTimeout(timeout);
+			}
+			return () => {};
+		}, [previews]);
+		const preview = previews[previewIndex];
+		return (
+			<div
+				key={card.name}
+				onClick={() => openCategory(card.name, index === 0 )}
+				role="button"
+				tabIndex={0}
+				onKeyDown={(event) => {
+					if (event.key === "Enter" || event.key === " ") {
+						event.preventDefault();
+						openCategory(card.name, index === 0);
+					}
+				}}
+				className={`card-generic card-cats group relative`}
+			>
+				<AnimatePresence initial={initial}>
+					<motion.div
+						key={previewIndex + preview?.src}
+						initial={{ opacity: 0, scale: 1.3, filter: "blur(8px)" }}
+						animate={{ opacity: 1, scale: 1.1, filter: "blur(0px)" }}
+						exit={{ opacity: 0, scale: 0.9, filter: "blur(8px)" }}
+						transition={{ duration: 1, type: "spring", delay: 0.1 * index }}
+						className="absolute w-full scale-110 group-hover:scale-100 fadein h-full flex items-center justify-center duration-200 rounded-t-lg data-gi:rounded-none pointer-events-none overflow-hidden"
+					>
+						<img
+							style={{
+								left: `calc(var(--card-cat-scale) * ${-(preview?.crop?.x || 0)}px)`,
+								top: `calc(var(--card-cat-scale) * ${-(preview?.crop?.y || 0)}px)`,
+								scale: preview?.crop?.scale || 1,
+								minWidth: "fit-content",
+								minHeight: "100%",
+							}}
+							className="w-full h-full relative object-contain object-center"
+							src={preview?.src || ""}
+							onError={(e) => {
+								handleImageError(e);
+								e.currentTarget.style.top= "calc(var(--card-cat-scale) * -10px)";
+							}}
+							onLoad={(e) => {
+								const img = e.currentTarget;
+								const aspect = img.naturalWidth / img.naturalHeight;
+								if (aspect > 1) {
+									img.style.minWidth = "fit-content";
+									img.style.minHeight = "100%";
+								} else {
+									img.style.minWidth = "14rem";
+									img.style.minHeight = "fit-content";
+								}
+							}}
+						/>
+					</motion.div>
+				</AnimatePresence>
+				<div className="absolute inset-0 bg-linear-to-t from-background via-background/35 to-transparent" />
+				<div className="absolute top-0 left-0 w-full gap-2 p-1 flex justify-between">
+					<div className="backdrop-blur-md h-10 border flex items-center gap-1 text-xs rounded-lg button-like px-2 text-accent bg-background/50">
+						{enabledCount}/{card.mods.length} enabled
+					</div>
+					{card.icon != "heart" && (
+						<Button
+							onMouseDown={(event) => event.stopPropagation()}
+							onMouseUp={(event) => event.stopPropagation()}
+							onClick={(event) => toggleCategoryFavorite(event, card.name)}
+							title={card.favorite ? "Remove favorite category" : "Add favorite category"}
+							className="shrink-0 w-10 h-10 rounded-lg border button-like pt-0 pl-0 pb-0 pr-0 hover:bg-background  bg-background/50 backdrop-blur-md"
+						>
+							<HeartIcon
+								className="min-h-5 min-w-5"
+								style={{
+									color: card.favorite ? "var(--color-red-400)" : "",
+									fill: card.favorite ? "currentColor" : "none",
+								}}
+							/>
+						</Button>
+					)}
+				</div>
+				<div className="absolute bottom-0 left-0 w-full gap-2 p-1.5 flex items-center">
+					{card.icon == "heart" ? (
+						<div
+							className="shrink-0 w-12 h-12 flex items-center justify-center rounded-lg border bg-background/50 backdrop-blur-md"
+						>
+							<HeartIcon
+								className="min-h-6 min-w-6"
+								style={{
+									color: card.favorite ? "var(--color-red-400)" : "",
+									fill: card.favorite ? "currentColor" : "none",
+								}}
+							/>
+						</div>
+					) : (
+						<img
+							src={card.icon || "/who.jpg"}
+							alt=""
+							onError={(event) => {
+								event.currentTarget.src = "/who.jpg";
+							}}
+							className="h-12 aspect-square rounded-lg border bg-background/50 backdrop-blur-md object-cover"
+						/>
+					)}
+
+					<h3 className="font-bold text-xl text-foreground">{card.name}</h3>
+				</div>
+			</div>
+		);
+	}
+);
+
+CardLocalCats.displayName = "CardLocalCats";
+
+export default CardLocalCats;

--- a/src/_Main/components/TopBar.tsx
+++ b/src/_Main/components/TopBar.tsx
@@ -3,6 +3,8 @@ import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
 	MOD_LIST,
+	LOCAL_NAVIGATION_MODE,
+	LOCAL_NAVIGATION_PAGE,
 	// LEFT_SIDEBAR_OPEN,
 	ONLINE,
 	ONLINE_DATA,
@@ -19,6 +21,9 @@ import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import {
 	DownloadIcon,
 	EyeIcon,
+	GalleryVerticalEndIcon,
+	LayoutGridIcon,
+	ListIcon,
 	// PanelLeftCloseIcon,
 	// PanelLeftOpenIcon,
 	// PanelRightCloseIcon,
@@ -45,6 +50,8 @@ function TopBar() {
 	const [onlineType, setOnlineType] = useAtom(ONLINE_TYPE);
 	const [onlineSort, setOnlineSort] = useAtom(ONLINE_SORT);
 	const [onlinePath, setOnlinePath] = useAtom(ONLINE_PATH);
+	const [localNavigationMode, setLocalNavigationMode] = useAtom(LOCAL_NAVIGATION_MODE);
+	const setLocalNavigationPage = useSetAtom(LOCAL_NAVIGATION_PAGE);
 	const [sort, setSort] = useAtom(SORT);
 	const [popoverOpen, setPopoverOpen] = useState(false);
 	const [search, setSearch] = useAtom(SEARCH);
@@ -131,6 +138,27 @@ function TopBar() {
 					}}
 				/>
 			</div>
+			{!online && (
+				<Button
+					onClick={() => {
+						const nextMode = {
+							classic: "categories",
+							categories: "vertical",
+							vertical: "classic",
+						}[localNavigationMode] as typeof localNavigationMode;
+						setLocalNavigationMode(nextMode);
+						if (nextMode !== "classic") setLocalNavigationPage("categories");
+					}}
+					className="bg-sidebar flex h-full min-w-12 items-center justify-center gap-2 rounded-lg border px-3"
+					aria-label={`Switch to ${localNavigationMode === "classic" ? "category" : localNavigationMode === "categories" ? "portrait" : "classic"} view`}
+					title={`Switch to ${localNavigationMode === "classic" ? "category" : localNavigationMode === "categories" ? "portrait" : "classic"} view`}
+				>
+					{localNavigationMode === "classic" ? <LayoutGridIcon className="h-4 w-4" /> : localNavigationMode === "categories" ? <GalleryVerticalEndIcon className="h-4 w-4" /> : <ListIcon className="h-4 w-4" />}
+					<span className="hidden 2xl:inline">
+						{localNavigationMode === "classic" ? "Category view" : localNavigationMode === "categories" ? "Portrait view" : "Classic view"}
+					</span>
+				</Button>
+			)}
 			<div className="data-wuwa:bg-sidebar data-wuwa:min-w-32 min-w-28 data-wuwa:border h-full bg-transparent border-0 rounded-lg">
 				{
 					<Popover open={popoverOpen} onOpenChange={setPopoverOpen}>

--- a/src/_RightSidebar/RightLocal.tsx
+++ b/src/_RightSidebar/RightLocal.tsx
@@ -5,10 +5,12 @@ import {
 	GAME,
 	INIT_DONE,
 	LAST_UPDATED,
+	LOCAL_NAVIGATION_MODE,
 	MOD_LIST,
 	ONLINE,
 	openConflict,
 	SELECTED,
+	RIGHT_SIDEBAR_OPEN,
 	SOURCE,
 	TEXT_DATA,
 } from "@/utils/vars";
@@ -194,6 +196,11 @@ function RightLocal() {
 	// const decor = useAtomValue(SETTINGS).global.winType
 	const [modList, setModList] = useAtom(MOD_LIST);
 	const [selected, setSelected] = useAtom(SELECTED);
+	const localNavigationMode = useAtomValue(LOCAL_NAVIGATION_MODE);
+	const setRightSidebarOpen = useSetAtom(RIGHT_SIDEBAR_OPEN);
+	useEffect(() => {
+		if (localNavigationMode === "vertical" && !selected) setRightSidebarOpen(false);
+	}, [localNavigationMode, selected, setRightSidebarOpen]);
 	const textData = useAtomValue(TEXT_DATA);
 	const [data, setData] = useAtom(DATA);
 	const [item, setItem] = useState<Mod | undefined>();

--- a/src/utils/decorations.tsx
+++ b/src/utils/decorations.tsx
@@ -2,7 +2,7 @@ import { Button } from "@/components/ui/button";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useAtom, useAtomValue } from "jotai";
 import { ArrowLeftIcon, ArrowRightIcon, MinusIcon, RectangleHorizontalIcon, XIcon } from "lucide-react";
-import { INIT_DONE, LEFT_SIDEBAR_OPEN, ONLINE, RIGHT_SIDEBAR_OPEN, RIGHT_SLIDEOVER_OPEN } from "./vars";
+import { INIT_DONE, LEFT_SIDEBAR_OPEN, LOCAL_NAVIGATION_MODE, ONLINE, RIGHT_SIDEBAR_OPEN, RIGHT_SLIDEOVER_OPEN } from "./vars";
 import Help from "@/_Main/components/Help";
 import Updater from "@/_Main/components/Updater";
 // import { createPortal } from "react-dom";
@@ -14,6 +14,8 @@ function Decorations() {
 	const [rightSlideOverOpen, setRightSlideOverOpen] = useAtom(RIGHT_SLIDEOVER_OPEN);
 	const online = useAtomValue(ONLINE);
 	const initDone = useAtomValue(INIT_DONE);
+	const localNavigationMode = useAtomValue(LOCAL_NAVIGATION_MODE);
+	const verticalLayout = !online && localNavigationMode === "vertical";
 	return (
 		<div
 			data-tauri-drag-region
@@ -23,7 +25,7 @@ function Decorations() {
 				<div
 					className="flex items-center h-full gap-1 -mr-2 text-xs duration-200 pointer-events-none"
 					style={{
-						minWidth: leftSidebarOpen ? "20.75rem" : "3.75rem",
+						minWidth: verticalLayout ? "3.75rem" : leftSidebarOpen ? "20.75rem" : "3.75rem",
 						justifyContent: leftSidebarOpen ? "" : "center",
 					}}
 				></div>
@@ -51,7 +53,7 @@ function Decorations() {
 					<div className="min-w-16 h-1"></div>
 					<div
 						style={{
-							marginLeft: rightSidebarOpen ? "" : "6.5rem",
+							marginLeft: verticalLayout || rightSidebarOpen ? "" : "6.5rem",
 						}}
 						className="flex items-center justify-center h-full gap-1"
 					>
@@ -62,7 +64,7 @@ function Decorations() {
 				</div>
 				<div
 					style={{
-						minWidth: rightSidebarOpen ? "16.25rem" : "1.5rem",
+						minWidth: verticalLayout ? "1.5rem" : rightSidebarOpen ? "16.25rem" : "1.5rem",
 					}}
 					className="flex items-center justify-start mx-1 duration-200"
 				>

--- a/src/utils/filesys.ts
+++ b/src/utils/filesys.ts
@@ -957,6 +957,7 @@ async function readDirRecr(
 		];
 	const filePromises = entries.map(async (entry) => {
 		if ((entry.name == RESTORE || entry.name == IGNORE || entry.name == PREFS) && cached && depth == 0) return null;
+		if(entry.name == ".imm-cache.json") return null;
 		let children: Mod[] = [];
 		if (entry.isDirectory && (!backupMode || (entry.name !== INI_BACKUP && !entry.name.startsWith(".imm"))))
 			children = await readDirRecr(root, join(path, entry.name), maxDepth, depth + 1, cached, backupMode);

--- a/src/utils/vars.ts
+++ b/src/utils/vars.ts
@@ -33,6 +33,10 @@ const DEV_HIDE_PREVIEWS = atomWithStorage("imm-dev-hide-previews", false);
 const SCALE = atomWithStorage("imm-scale", 0);
 const BLUR = atomWithStorage("imm-blur", 1);
 const ANIMATIONS = atomWithStorage("imm-animations", true);
+export type LocalNavigationMode = "classic" | "categories" | "vertical";
+const LOCAL_NAVIGATION_MODE = atomWithStorage<LocalNavigationMode>("imm-local-navigation-mode", "classic");
+const LOCAL_NAVIGATION_PAGE = atom<"categories" | "mods">("categories");
+const LOCAL_CATEGORY_FAVORITES = atomWithStorage<string[]>("imm-local-category-favorites", []);
 const BACKUP_INI = atomWithStorage("imm-backup-ini", false);
 const INIT_DONE = atom(false);
 const MAIN_FUNC_STATUS = atom<string>("");
@@ -203,5 +207,8 @@ export {
 	SCALE,
 	BLUR,
 	ANIMATIONS,
+	LOCAL_NAVIGATION_MODE,
+	LOCAL_NAVIGATION_PAGE,
+	LOCAL_CATEGORY_FAVORITES,
 	BACKUP_INI,
 };


### PR DESCRIPTION
## Summary

- Keeps the original classic installed-mod list as the default view.
- Adds a category browser with full folder-card styling: background previews, category icons, favorites, enabled-mod counts, and folder metadata.
- Adds a third Portrait view with denser, fluid cards for vertical monitors.
- Cycles between Classic, Category, and Portrait from a single top-bar button.

## Portrait view behavior

- Starts with both sidebars collapsed to maximize horizontal space.
- Opens the left navigation and right details panel as overlay drawers instead of shrinking the mod grid.
- Opens the details drawer when a mod is selected and closes it when the selection is cleared.
- Closes either drawer from the dimmed backdrop.
- Restores the previous sidebar state when leaving Portrait view.

## Compatibility and scope

- Rebuilt on the current upstream `main` (`4.0.0`).
- Preserves the original Unicode characters from upstream.
- Contains navigation and layout behavior only; it does not include provider, download-source, translation, or private integration changes.

## Validation

- `npm run build`
- `npm run lint -- --quiet`
- `git diff --check`